### PR TITLE
Updated README.md to document inclusion of default recipe for LWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Set vm.swapiness to 20 via attributes
 
 The `sysctl_param` LWRP can be called from wrapper and application cookbooks to immediately set the kernel parameter and cue the kernel parameter to be written out to the configuration file.
 
+This also requires that your run_list include the `sysctl::default` recipe in order to persist the settings.
+
 ### sysctl_param
 
 Actions
@@ -72,6 +74,8 @@ Attributes
 Set vm.swapiness to 20 via sysctl_param LWRP
 
 ```` ruby
+    include_recipe 'sysctl::default'
+
     sysctl_param 'vm.swappiness' do
       value 20
     end


### PR DESCRIPTION
Continuing thread from issue: https://github.com/onehealth-cookbooks/sysctl/issues/9

Admittedly it does make sense to always persist sysctl settings, and I can't think of a use case why you wouldn't want to. I brought up this issue more as general idea to clear up some confusion around the documentation.

Generally, when using LWRPs, you don't need to include recipes for them to work. However, in the `sysctl` cookbook's case, there's a hard dependency on the recipe, so the examples should reflect this.
