### PR TITLE
Fix to handle chef 12 metadata attributes in Chef 11. Update integration test for serverspec2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 3.2.0'
+gem 'berkshelf', '~> 3.2.0'
 
 group :unit do
   gem 'foodcritic',       '~> 4.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,42 @@
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+require 'foodcritic'
+require 'kitchen'
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef) do |t|
+    t.options = {
+      fail_tags: ['any'],
+      tags: []
+    }
+  end
+end
+
+desc 'Run all style checks'
+task style: %w(style:chef style:ruby)
+
+# Rspec and ChefSpec
+desc 'Run ChefSpec examples'
+RSpec::Core::RakeTask.new(:spec)
+
+# Integration tests. Kitchen.ci
+namespace :integration do
+  desc 'Run Test Kitchen with Vagrant'
+  task :vagrant do
+    Kitchen.logger = Kitchen.default_file_logger
+    Kitchen::Config.new.instances.each do |instance|
+      instance.test(:always)
+    end
+  end
+end
+
+desc 'Run all tests on Travis'
+task travis: %w(style spec)
+
+# Default
+task default: %w(style spec integration:vagrant)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,8 @@
 name 'sysctl'
 maintainer 'Sander van Zoest'
 maintainer_email 'sander+cookbooks@vanzoest.com'
-issues_url 'https://github.com/svanzoest-cookbooks/sysctl/issues'
-source_url 'https://github.com/svanzoest-cookbooks/sysctl/'
+issues_url 'https://github.com/svanzoest-cookbooks/sysctl/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/svanzoest-cookbooks/sysctl/' if respond_to?(:source_url)
 license 'Apache v2.0'
 description 'Configures sysctl parameters'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,13 +21,12 @@
 
 include_recipe 'sysctl::service'
 
-if node['sysctl']['conf_dir']
-  directory node['sysctl']['conf_dir'] do
-    owner 'root'
-    group 'root'
-    mode 0755
-    action :create
-  end
+directory node['sysctl']['conf_dir'] do
+  owner 'root'
+  group 'root'
+  mode 0755
+  action :create
+  only_if { node['sysctl']['conf_dir'] }
 end
 
 if Sysctl.config_file(node)

--- a/test/integration/attributes/serverspec/attrs_spec.rb
+++ b/test/integration/attributes/serverspec/attrs_spec.rb
@@ -10,8 +10,8 @@ describe file('/proc/sys/vm/swappiness') do
   it { should contain '19' }
 end
 
-persistence_file = case os[:family]
-                   when 'RedHat', 'Fedora', 'Debian', 'Ubuntu'
+persistence_file = case os[:family].downcase
+                   when 'redhat', 'fedora', 'debian', 'ubuntu'
                      '/etc/sysctl.d/99-chef-attributes.conf'
                    else
                      '/etc/sysctl.conf'

--- a/test/integration/attributes/serverspec/spec_helper.rb
+++ b/test/integration/attributes/serverspec/spec_helper.rb
@@ -1,7 +1,3 @@
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-
-def os
-  backend(Serverspec::Commands::Base).check_os
-end
+set :backend, :exec

--- a/test/integration/default/serverspec/attrs_spec.rb
+++ b/test/integration/default/serverspec/attrs_spec.rb
@@ -10,8 +10,8 @@ describe file('/proc/sys/vm/swappiness') do
   it { should contain '19' }
 end
 
-persistence_file = case os[:family]
-                   when 'RedHat', 'Fedora', 'Debian', 'Ubuntu'
+persistence_file = case os[:family].downcase
+                   when 'redhat', 'fedora', 'debian', 'ubuntu'
                      '/etc/sysctl.d/99-chef-attributes.conf'
                    else
                      '/etc/sysctl.conf'

--- a/test/integration/default/serverspec/lwrps_spec.rb
+++ b/test/integration/default/serverspec/lwrps_spec.rb
@@ -10,8 +10,8 @@ describe file('/proc/sys/net/ipv4/tcp_rmem') do
   it { should contain '4096	16384	33554432' }
 end
 
-persistence_file = case os[:family]
-                   when 'RedHat', 'Fedora', 'Debian', 'Ubuntu'
+persistence_file = case os[:family].downcase
+                   when 'redhat', 'fedora', 'debian', 'ubuntu'
                      '/etc/sysctl.d/99-chef-attributes.conf'
                    else
                      '/etc/sysctl.conf'

--- a/test/integration/default/serverspec/ohai_plugin_spec.rb
+++ b/test/integration/default/serverspec/ohai_plugin_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
 describe command('ohai -d /etc/chef/ohai_plugins sys') do
-  it { should return_exit_status 0 }
-  it { should return_stdout(/"net": {/) }
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match %r("net": {/) }
 end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,7 +1,3 @@
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-
-def os
-  backend(Serverspec::Commands::Base).check_os
-end
+set :backend, :exec

--- a/test/integration/lwrps/serverspec/lwrps_spec.rb
+++ b/test/integration/lwrps/serverspec/lwrps_spec.rb
@@ -10,8 +10,8 @@ describe file('/proc/sys/net/ipv4/tcp_rmem') do
   it { should contain '4096	16384	33554432' }
 end
 
-persistence_file = case os[:family]
-                   when 'RedHat', 'Fedora', 'Debian', 'Ubuntu'
+persistence_file = case os[:family].downcase
+                   when 'redhat', 'fedora', 'debian', 'ubuntu'
                      '/etc/sysctl.d/99-chef-attributes.conf'
                    else
                      '/etc/sysctl.conf'

--- a/test/integration/lwrps/serverspec/spec_helper.rb
+++ b/test/integration/lwrps/serverspec/spec_helper.rb
@@ -1,7 +1,3 @@
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-
-def os
-  backend(Serverspec::Commands::Base).check_os
-end
+set :backend, :exec


### PR DESCRIPTION
"source_url" and "issues_url" are Chef 12 metadata attributes that do not have backwards compatibility.
The last version of Kitchen-ci use serverspec2. I modify spec_helper.rb in test/integration.
