### PR TITLE
Fix enabling Chef 13 warnings as errors

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,10 +8,9 @@ provisioner:
   roles_path: "roles"
   environments_path: "environments"
   require_chef_omnibus: true
-
-client_rb:
-  treat_deprecation_warnings_as_errors: true
-  resource_cloning: false
+  solo_rb:
+    treat_deprecation_warnings_as_errors: true
+    resource_cloning: false
 
 platforms:
 - name: ubuntu-14.04


### PR DESCRIPTION
## Description

The YAML keys used here and other cookbooks to enable treating Chef 13 warnings as errors are wrong. They are currently being ignored.

After doing some tests, I think the [Preparing for Chef Client 13](https://blog.chef.io/2017/01/30/preparing-for-chef-13/) blog post example is a bit incomplete. Two things should be clarified:

- Those options must be under the `provisioner` key.
- Test-kitchen uses `chef_solo` provisioner by default. The correct sub-key used for Chef Solo is `solo_rb`, not `client_rb`.

So, the proper way to enable them with **Chef Solo** is:

```yaml
provisioner:
  name: chef_solo # This is the default value if not specified
  solo_rb:
    treat_deprecation_warnings_as_errors: true
    resource_cloning: false
```

If you want to enable them with **Chef Zero**:

```yaml
provisioner:
  name: chef_zero
  client_rb:
    treat_deprecation_warnings_as_errors: true
    resource_cloning: false
```

There is a way that works **for both** Chef Solo and Chef Zero, but AFAIK there is no way to disable resource cloning:
```yaml
provisioner:
  deprecations_as_errors: true
```

### Issues Resolved

- [#72: sysctl Chef-13](https://github.com/sous-chefs/sysctl/issues/72) ?
- [#71: Chef 13 warnings turned on](https://github.com/sous-chefs/sysctl/issues/71)

### Related Issues in Other Cookbooks

- [mongodb#126: Chef 13 warnings turned on](https://github.com/sous-chefs/mongodb/pull/126)
- [mongodb#129 Chef-13](https://github.com/sous-chefs/mongodb/pull/129)
- [samba#13 samba Chef-13](https://github.com/sous-chefs/samba/issues/58)

### Check List
- [x] All tests pass.
- ~New functionality includes testing~
- ~New functionality has been documented in the README if applicable~

CC @thommay