### PR TITLE
Adding attribute to control whether or not cookbook should reload sysctl on the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ There are two main ways to interact with the cookbook. This is via chef [attribu
 * `node['sysctl']['params']` - A namespace for setting sysctl parameters.
 * `node['sysctl']['conf_dir']` - Specifies the sysctl.d directory to be used. Defaults to `/etc/sysctl.d` on the Debian and RHEL platform families, otherwise `nil`
 * `node['sysctl']['allow_sysctl_conf']` - Defaults to false.  Using `conf_dir` is highly recommended. On some platforms that is not supported. For those platforms, set this to `true` and the cookbook will rewrite the `/etc/sysctl.conf` file directly with the params provided. Be sure to save any local edits of `/etc/sysctl.conf` before enabling this to avoid losing them.
+* `node['sysctl']['restart_procps']` - Defaults to true. Will allow the consumer of the cookbook to control whether or not to notify procps to restart sysctl to load the newly set values.
 
 Note: if `node['sysctl']['conf_dir']` is set to nil and `node['sysctl']['allow_sysctl_conf']` is not set, no config will be written
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@ default['sysctl']['params'] = {}
 default['sysctl']['allow_sysctl_conf'] = false
 default['sysctl']['conf_file'] = '/etc/sysctl.conf'
 default['sysctl']['conf_dir'] = nil
+default['sysctl']['restart_procps'] = true
 
 if platform_family?('freebsd')
   default['sysctl']['allow_sysctl_conf'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -71,6 +71,6 @@ if sysctl_config_file
     action :nothing
     source 'sysctl.conf.erb'
     mode '0644'
-    notifies :restart, 'service[procps]', :immediately
+    notifies :restart, 'service[procps]', :immediately if node['sysctl']['restart_procps']
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -73,7 +73,7 @@ describe 'sysctl::default' do
       end
     end
   end
-  
+
   versions = ['5.9', '6.4']
   versions.each do |version|
     context "on Centos #{version}" do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -73,7 +73,7 @@ describe 'sysctl::default' do
       end
     end
   end
-
+  
   versions = ['5.9', '6.4']
   versions.each do |version|
     context "on Centos #{version}" do

--- a/spec/restart_false_spec.rb
+++ b/spec/restart_false_spec.rb
@@ -31,7 +31,7 @@ describe 'sysctl::default' do
           else
             chef_run.template('/etc/sysctl.d/99-chef-attributes.conf')
           end
-        end              
+        end
         it 'should not restart procps if restart_procps is false' do
           expect(template).to_not notify('service[procps]').immediately if expect(chef_run.node['sysctl']['restart_procps']).to be false
         end

--- a/spec/restart_false_spec.rb
+++ b/spec/restart_false_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+# examples at https://github.com/sethvargo/chefspec/tree/master/examples
+
+describe 'sysctl::default' do
+  platforms = {
+    'ubuntu' => ['14.04', '16.04'],
+    'debian' => ['7.11', '8.7'],
+    'fedora' => ['25'],
+    'redhat' => ['6.8', '7.3'],
+    'centos' => ['6.8', '7.3.1611'],
+    'freebsd' => ['10.3', '11.0'],
+    'suse' => ['12.2'],
+  }
+
+  # Test all generic stuff on all platforms
+  platforms.each do |platform, versions|
+    versions.each do |version|
+      context "on #{platform.capitalize} #{version}" do
+        let(:chef_run) do
+          ChefSpec::SoloRunner.new(platform: platform, version: version) do |node|
+            node.override['sysctl']['restart_procps'] = false
+          end.converge('sysctl::default')
+        end
+
+        let(:template) do
+          if platform == 'freebsd'
+            chef_run.template('/etc/sysctl.conf.local')
+          elsif platform == 'suse' && version.to_f < 12.0
+            chef_run.template('/etc/sysctl.conf')
+          else
+            chef_run.template('/etc/sysctl.d/99-chef-attributes.conf')
+          end
+        end              
+        it 'should not restart procps if restart_procps is false' do
+          expect(template).to_not notify('service[procps]').immediately if expect(chef_run.node['sysctl']['restart_procps']).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding attribute to control whether or not cookbook should reload sysctl on the system

## Description

This will allow the consumer of the cookbook to override the default action of procps by setting the value of `node['sysctl']['restart_procps'] = false` the cookbook would no longer restart sysctl immediately if changes were made. This would allow for 'staging' of values. This is currently preferred in the enterprise environment I am in.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
