### PR TITLE
WIP: Add a custom resource for reloading systctl data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ env:
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
   - INSTANCE=default-fedora-25
-  # - INSTANCE=default-opensuse-leap
+  - INSTANCE=default-opensuse-leap
   - INSTANCE=resources-debian-7
   - INSTANCE=resources-debian-8
   - INSTANCE=resources-centos-6
   - INSTANCE=resources-centos-7
   - INSTANCE=resources-fedora-25
   - INSTANCE=resources-ubuntu-1604
-  # - INSTANCE=resources-opensuse-leap
+  - INSTANCE=resources-opensuse-leap
   - INSTANCE=attributes-debian-7
   - INSTANCE=attributes-debian-8
   - INSTANCE=attributes-centos-6

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['sysctl']['params'] = {}
 default['sysctl']['allow_sysctl_conf'] = false
 default['sysctl']['conf_file'] = '/etc/sysctl.conf'
 default['sysctl']['conf_dir'] = nil
-default['sysctl']['restart_procps'] = true
+default['sysctl']['reload_systctl'] = true
 
 if platform_family?('freebsd')
   default['sysctl']['allow_sysctl_conf'] = true

--- a/recipes/apply.rb
+++ b/recipes/apply.rb
@@ -22,5 +22,5 @@ include_recipe 'sysctl::default'
 ruby_block 'notify-apply-sysctl-params' do
   block do
   end
-  notifies :run, 'ruby_block[apply-sysctl-params]', :immediately
+  notifies :reload, 'sysctl_reload[reload sysctl]', :immediately if node['sysctl']['reload_systctl']
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,14 +56,6 @@ if sysctl_config_file
     notifies :create, "template[#{sysctl_config_file}]", :delayed
   end
 
-  # this is called by the sysctl::apply recipe to trigger template creation
-  ruby_block 'apply-sysctl-params' do
-    action :nothing
-    block do
-    end
-    notifies :create, "template[#{sysctl_config_file}]", :immediately
-  end
-
   # this needs to have an action in case node.sysctl.params has changed
   # and also needs to be called for persistence on resource changes via the
   # ruby_block
@@ -71,6 +63,11 @@ if sysctl_config_file
     action :nothing
     source 'sysctl.conf.erb'
     mode '0644'
-    notifies :restart, 'service[procps]', :immediately if node['sysctl']['restart_procps']
+    notifies :reload, 'sysctl_reload[reload sysctl]', :immediately if node['sysctl']['reload_systctl']
   end
+end
+
+# for notifcation purposes
+sysctl_reload 'reload sysctl' do
+  action :nothing
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -17,13 +17,16 @@
 # limitations under the License.
 #
 
+# systemd handles loading the sysctl configs itself so don't run these
 template '/etc/rc.d/init.d/procps' do
   source 'procps.init-rhel.erb'
   mode '0755'
-  only_if { platform_family?('rhel', 'fedora', 'pld') }
+  only_if { platform_family?('rhel', 'pld') }
+  not_if { node['init_package'] == 'systemd' }
 end
 
 service 'procps' do
   supports restart: true, reload: true, status: false
   action :enable
+  not_if { node['init_package'] == 'systemd' }
 end

--- a/resources/reload.rb
+++ b/resources/reload.rb
@@ -1,0 +1,13 @@
+action :reload do
+  if node['init_package'] == 'systemd'
+    execute 'reload sysctl via systemd' do
+      command '/usr/lib/systemd/systemd-sysctl'
+      action :run
+    end
+  else
+    service 'procps' do
+      supports restart: true, reload: true, status: false
+      action :restart
+    end
+  end
+end

--- a/test/cookbooks/sysctl_test/recipes/default.rb
+++ b/test/cookbooks/sysctl_test/recipes/default.rb
@@ -19,17 +19,14 @@
 #
 include_recipe 'sysctl'
 
-# sysctl_param 'net.ipv4.tcp_max_syn_backlog' do
-#  value 12_345
-# end
+sysctl_param 'net.ipv4.tcp_max_syn_backlog' do
+ value 12_345
+end
 
 # sysctl_param 'net.ipv4.tcp_rmem' do
 #  value '4096 16384 33554432'
 # end
 #
-sysctl_param 'dev.cdrom.autoeject' do
-  value 1
-end
 
 sysctl_param 'vm.swappiness' do
   value '19'

--- a/test/integration/attributes/attrs_spec.rb
+++ b/test/integration/attributes/attrs_spec.rb
@@ -1,6 +1,6 @@
-describe file('/proc/sys/dev/cdrom/autoeject') do
+describe file('/proc/sys/net/ipv4/tcp_max_syn_backlog') do
   it { should be_file }
-  its('content') { should match /1/ }
+  its('content') { should match /12345/ }
 end
 
 describe file('/proc/sys/vm/swappiness') do
@@ -22,5 +22,5 @@ end
 describe file(persistence_file) do
   it { should be_file }
   its('content') { should match /vm.swappiness=19/ }
-  its('content') { should match /dev.cdrom.autoeject=1/ }
+  its('content') { should match /net.ipv4.tcp_max_syn_backlog=12345/ }
 end

--- a/test/integration/default/attrs_spec.rb
+++ b/test/integration/default/attrs_spec.rb
@@ -1,6 +1,6 @@
-describe file('/proc/sys/dev/cdrom/autoeject') do
+describe file('/proc/sys/net/ipv4/tcp_max_syn_backlog') do
   it { should be_file }
-  its('content') { should match /1/ }
+  its('content') { should match /12345/ }
 end
 
 describe file('/proc/sys/vm/swappiness') do
@@ -22,5 +22,5 @@ end
 describe file(persistence_file) do
   it { should be_file }
   its('content') { should match /vm.swappiness=19/ }
-  its('content') { should match /dev.cdrom.autoeject=1/ }
+  its('content') { should match /net.ipv4.tcp_max_syn_backlog=12345/ }
 end

--- a/test/integration/default/lwrps_spec.rb
+++ b/test/integration/default/lwrps_spec.rb
@@ -16,6 +16,6 @@ end
 
 describe file(persistence_file) do
   it { should be_file }
-  its('content') { should match /dev.cdrom.autoeject=1/ }
+  its('content') { should match /net.ipv4.tcp_max_syn_backlog=12345/ }
   its('content') { should match /vm.swappiness=19/ }
 end

--- a/test/integration/resources/lwrps_spec.rb
+++ b/test/integration/resources/lwrps_spec.rb
@@ -1,6 +1,6 @@
-describe file('/proc/sys/dev/cdrom/autoeject') do
+describe file('/proc/sys/net/ipv4/tcp_max_syn_backlog') do
   it { should be_file }
-  its('content') { should match /1/ }
+  its('content') { should match /12345/ }
 end
 
 persistence_file = case os[:family].downcase
@@ -16,6 +16,6 @@ end
 
 describe file(persistence_file) do
   it { should be_file }
-  its('content') { should match /dev.cdrom.autoeject=1/ }
+  its('content') { should match /net.ipv4.tcp_max_syn_backlog=12345/ }
   its('content') { should match /vm.swappiness=19/ }
 end


### PR DESCRIPTION
Previously we managed procps and reloaded it if an attribute was set. We did that through some funky notifications. The problem is systemd based systems have their own systemd way of reloading sysctl data. This is a super simple resource that just decides the best thing to do and does it. We notify that resource instead of the ruby block / service restart stuff before.

Signed-off-by: Tim Smith <tsmith@chef.io>