### PR TITLE
[GH-85] Added Amazon Linux to list of supported platform family

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -74,3 +74,11 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
+
+- name: amazon-2017.03
+  driver:
+    image: amazonlinux:2017.03
+    platform: amazon
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN yum -y install lsof which initscripts net-tools wget net-tools

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,7 @@ platforms:
 - name: opensuse-leap-42.2
 - name: ubuntu-14.04
 - name: ubuntu-16.04
+- name: amazon-2017.03
 
 suites:
 - name: resources

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - INSTANCE=resources-fedora-25
   - INSTANCE=resources-ubuntu-1604
   # - INSTANCE=resources-opensuse-leap
+  - INSTANCE=resources-amazon-201703
   - INSTANCE=attributes-debian-7
   - INSTANCE=attributes-debian-8
   - INSTANCE=attributes-centos-6
@@ -34,6 +35,7 @@ env:
   - INSTANCE=attributes-ubuntu-1404
   - INSTANCE=attributes-ubuntu-1604
   # - INSTANCE=attributes-opensuse-leap
+  - INSTANCE=attributes-amazon-201703
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Sysctl
 
+## v0.9.1 (2017-07-25)
+- [GH-85] Added support for Amazon Linux as a platform for Chef 13 support
+
 ## v0.9.0 (2017-05-18)
 
 - This cookbook is now maintained by Sous-Chefs. See <http://sous-chefs.org/>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Set [sysctl](http://en.wikipedia.org/wiki/Sysctl) system control parameters via 
 - Arch Linux
 - openSUSE
 - FreeBSD
+- Amazon Linux
 
 ### Chef
 

--- a/libraries/helpers_param.rb
+++ b/libraries/helpers_param.rb
@@ -9,7 +9,7 @@ module SysctlCookbook
         case node['platform_family']
         when 'freebsd'
           false
-        when 'arch', 'debian', 'rhel', 'fedora'
+        when 'arch', 'debian', 'rhel', 'fedora', 'amazon'
           true
         when 'suse'
           node['platform_version'].to_f < 12.0 ? false : true

--- a/libraries/sysctl_param.rb
+++ b/libraries/sysctl_param.rb
@@ -28,7 +28,7 @@ module SysctlCookbook
           cookbook 'sysctl'
           source 'procps.init-rhel.erb'
           mode '0775'
-          only_if { platform_family?('rhel', 'fedora', 'pld') }
+          only_if { platform_family?('rhel', 'fedora', 'pld', 'amazon') }
         end
 
         s = service_type

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/sous-chefs/sysctl'
 license 'Apache-2.0'
 description 'Configures sysctl parameters'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.0'
+version '0.9.1'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'ubuntu', '>= 14.04'
@@ -16,5 +16,6 @@ supports 'scientific', '>= 6.4'
 supports 'suse', '>= 11.0'
 supports 'redhat'
 supports 'pld'
+supports 'amazon'
 
 depends 'ohai', '>= 4.0'

--- a/spec/restart_false_spec.rb
+++ b/spec/restart_false_spec.rb
@@ -11,6 +11,7 @@ describe 'sysctl::default' do
     'centos' => ['6.8', '7.3.1611'],
     'freebsd' => ['10.3', '11.0'],
     'suse' => ['12.2'],
+    'amazon' => ['2017.03'],
   }
 
   # Test all generic stuff on all platforms


### PR DESCRIPTION
### Description

Added support for Amazon Linux platform family in Chef 13

### Issues Resolved

[GH-85] Support for amazon platform

### Check List
- [x] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
