### PR TITLE
library should reference conf_dir not conf_file

### DIFF
--- a/libraries/helpers_param.rb
+++ b/libraries/helpers_param.rb
@@ -21,7 +21,7 @@ module SysctlCookbook
       end
 
       def config_sysctl
-        return node['sysctl']['conf_file'] if node['sysctl'].attribute?('conf_file')
+        return node['sysctl']['conf_dir'] if node['sysctl'].attribute?('conf_dir')
 
         case node['platform_family']
         when 'freebsd'
@@ -34,8 +34,8 @@ module SysctlCookbook
       end
 
       def confd_sysctl
-        if node['sysctl'].attribute?('conf_file')
-          node['sysctl']['conf_file']
+        if node['sysctl'].attribute?('conf_dir')
+          node['sysctl']['conf_dir']
         else
           '/etc/sysctl.d'
         end


### PR DESCRIPTION
### Description

With 0.10.0 conf_file was deprecated however there are still incorrect references in code to that attribute. The references that are to `conf_file` should be to `conf_dir`. If conf_file is specified then no sysctl entries can be added to a node

```
    * template[/etc/sysctl.d/99-chef-attributes.conf/99-chef-kernel.core_uses_pid.conf] action create
      * Parent directory /etc/sysctl.d/99-chef-attributes.conf does not exist.
      ================================================================================
      Error executing action `create` on resource 'template[/etc/sysctl.d/99-chef-attributes.conf/99-chef-kernel.core_uses_pid.conf]'
      ================================================================================

      Chef::Exceptions::EnclosingDirectoryDoesNotExist
      ------------------------------------------------
Parent directory /etc/sysctl.d/99-chef-attributes.conf does not exist.
```


### Issues Resolved

Unsure

### Check List
- [ ] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
