### PR TITLE
Adding attribute to handle with sysctl -e flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ There are two main ways to interact with the cookbook. This is via chef [attribu
 - `node['sysctl']['conf_dir']` - Specifies the sysctl.d directory to be used. Defaults to `/etc/sysctl.d` on the Debian and RHEL platform families, otherwise `nil`
 - `node['sysctl']['allow_sysctl_conf']` - Defaults to false. Using `conf_dir` is highly recommended. On some platforms that is not supported. For those platforms, set this to `true` and the cookbook will rewrite the `/etc/sysctl.conf` file directly with the params provided. Be sure to save any local edits of `/etc/sysctl.conf` before enabling this to avoid losing them.
 - `node['sysctl']['restart_procps']` - Defaults to true. Will allow the consumer of the cookbook to control whether or not to notify procps to restart sysctl to load the newly set values.
+- `node['sysctl']['ignore_error']` - Defaults is not set. If true, this will allow the consumer of the cookbook to control whether or not to utilize '-e' flag within actual sysctl command.
 
 Note: if `node['sysctl']['conf_dir']` is set to nil and `node['sysctl']['allow_sysctl_conf']` is not set, no config will be written
 

--- a/libraries/helpers_param.rb
+++ b/libraries/helpers_param.rb
@@ -42,7 +42,7 @@ module SysctlCookbook
       end
 
       def get_sysctl_value(key)
-        o = shell_out("sysctl -n #{key}")
+        o = shell_out("sysctl -n #{'-e ' if node['sysctl']['ignore_error']}#{key}")
         raise 'Unknown sysctl key!' if o.error!
         o = o.stdout.tr("\t", ' ').strip
         raise unless o == get_sysctld_value(key)
@@ -58,7 +58,7 @@ module SysctlCookbook
       end
 
       def set_sysctl_param(key, value)
-        o = shell_out("sysctl -w \"#{key}=#{value}\"")
+        o = shell_out("sysctl #{'-e ' if node['sysctl']['ignore_error']}-w \"#{key}=#{value}\"")
         return false if o.error!
         true
       end

--- a/spec/conf_dir_spec.rb
+++ b/spec/conf_dir_spec.rb
@@ -3,16 +3,6 @@ require 'spec_helper'
 # examples at https://github.com/sethvargo/chefspec/tree/master/examples
 
 describe 'sysctl::default' do
-  platforms = {
-    'ubuntu' => ['14.04', '16.04'],
-    'debian' => ['7.11', '8.8'],
-    'fedora' => ['25'],
-    'redhat' => ['6.9', '7.3'],
-    'centos' => ['6.9', '7.3.1611'],
-    'freebsd' => ['10.3', '11.0'],
-    'suse' => ['12.2'],
-  }
-
   # Test all generic stuff on all platforms
   platforms.each do |platform, versions|
     versions.each do |version|

--- a/spec/ignore_error_spec.rb
+++ b/spec/ignore_error_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'sysctl::default' do
+  platforms.each do |platform, versions|
+    versions.each do |version|
+      context "on #{platform.capitalize} #{version}" do
+        let(:fake_sysctl_value) { 90 }
+        let(:fake_shellout) { instance_double('Mixlib::ShellOut', error!: false, stdout: fake_sysctl_value, live_stream: STDOUT, run_command: nil) }
+        let(:chef_run) do
+          ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['sysctl_param']) do |node|
+            node.default['sysctl']['ignore_error'] = ignore_error
+            node.default['sysctl']['params']['vm']['swappiness'] = fake_sysctl_value
+            allow(Mixlib::ShellOut).to receive(:new).and_return(fake_shellout)
+          end.converge('sysctl::default')
+        end
+
+        context 'when ignore_error is true' do
+          let(:ignore_error) { true }
+
+          it 'expects shell_out sysctl command with -e flag' do
+            expect(Mixlib::ShellOut).to receive(:new).with(/sysctl -n -e vm.*/, anything)
+            expect(Mixlib::ShellOut).to receive(:new).with(/sysctl -e -w "vm.*/, anything)
+            chef_run
+          end
+        end
+
+        context 'when ignore_error is false' do
+          let(:ignore_error) { false }
+
+          it 'expects shell_out sysctl command without -e flag' do
+            expect(Mixlib::ShellOut).to receive(:new).with(/^sysctl -n vm.*/, anything)
+            expect(Mixlib::ShellOut).to receive(:new).with(/^sysctl -w "vm.*/, anything)
+            chef_run
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/restart_spec.rb
+++ b/spec/restart_spec.rb
@@ -3,16 +3,6 @@ require 'spec_helper'
 # examples at https://github.com/sethvargo/chefspec/tree/master/examples
 
 describe 'sysctl::default' do
-  platforms = {
-    'ubuntu' => ['14.04', '16.04'],
-    'debian' => ['7.11', '8.8'],
-    'fedora' => ['25'],
-    'redhat' => ['6.9', '7.3'],
-    'centos' => ['6.9', '7.3.1611'],
-    'freebsd' => ['10.3', '11.0'],
-    'suse' => ['12.2'],
-  }
-
   # Test all generic stuff on all platforms
   platforms.each do |platform, versions|
     versions.each do |version|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,22 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'mixlib/shellout'
 
 RSpec.configure do |config|
   config.formatter = :documentation
   config.color = true
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+end
+
+def platforms
+  {
+    'ubuntu' => ['14.04', '16.04'],
+    'debian' => ['7.11', '8.8'],
+    'fedora' => ['25'],
+    'redhat' => ['6.9', '7.3'],
+    'centos' => ['6.9', '7.3.1611'],
+    'freebsd' => ['10.3', '11.0'],
+    'suse' => ['12.2'],
+  }
 end


### PR DESCRIPTION
### Description

This change would allow using -e for sysctl command through additional attribute node['sysctl']['ignore_error']. 

### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
