### PR TITLE
Fix for node['sysctl']['restart_procps'] attribute default

### DIFF
--- a/libraries/helpers_param.rb
+++ b/libraries/helpers_param.rb
@@ -17,7 +17,8 @@ module SysctlCookbook
       end
 
       def restart_procps?
-        return node['sysctl']['restart_procps'] if node['sysctl'].attribute?('restart_procps')
+        return true unless node['sysctl'].attribute?('restart_procps')
+        node['sysctl']['restart_procps']
       end
 
       def config_sysctl


### PR DESCRIPTION
Signed-off-by: Nathan Dines <nath@ndin.es>

### Description

Despite the README stating `true` as the default for the `node['sysctl']['restart_procps']` attribute, this was not being set anywhere. This change sets the default to `true` if the attribute is not otherwise set ([as per the README](https://github.com/sous-chefs/sysctl/blob/master/README.md#cookbook-attributes)).

The alternative approach would be to adjust the README to state that the attribute defaults to `undefined`, but I believe that the service should restart by default when procps is configured on nodes to ensure that the state of the system before and after system restart are as consistent as possible.

I've been working against Amazon Linux matching the following platform criteria in test kitchen using the `kitchen-ec2` driver:

```
platforms:
  - name: amazon-ec2
    driver:
      image_search:
        name: "amzn-ami-hvm-????.??.?.????????-x86_64-gp2"
        owner-alias: "amazon"
        virtualization-type: hvm
    state: available
```

### Issues Resolved

- N/A

### Check List
- [ ] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
