### PR TITLE
Use the bento slugs in Test Kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,13 +12,13 @@ platforms:
 - name: amazon-linux
   driver_config:
     box: mvbcoding/awslinux
-- name: centos-6.9
-- name: centos-7.3
-- name: debian-7.11
-- name: debian-8.8
-- name: debian-9.0
-- name: fedora-25
-- name: freebsd-11.0
+- name: centos-6
+- name: centos-7
+- name: debian-8
+- name: debian-9
+- name: fedora-27
+- name: freebsd-10
+- name: freebsd-11
 - name: opensuse-leap-42.2
 - name: ubuntu-14.04
 - name: ubuntu-16.04


### PR DESCRIPTION
Nuke Debian 7, add FreeBSD 10, use the Bento slugs. Thanks again @cheeseplus

Signed-off-by: Tim Smith <tsmith@chef.io>
