### PR TITLE
always persist params (#112)

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -12,6 +12,12 @@ module SysctlCookbook
         o.stdout.to_s.tr("\t", ' ').strip
       end
 
+      def get_sysctld_value(key)
+        return nil unless ::File.exist?("/etc/sysctl.d/99-chef-#{key}.conf")
+        k, v = IO.read("/etc/sysctl.d/99-chef-#{key}.conf").match(/(.*) = (.*)/).captures
+        v
+      end
+
       def coerce_value(v)
         case v
         when Array

--- a/resources/param.rb
+++ b/resources/param.rb
@@ -36,7 +36,14 @@ property :restart_procps, [true, false], default: true
 include SysctlCookbook::SysctlHelpers::Param
 
 load_current_value do
-  value get_sysctl_value(key)
+  sysctl_value = get_sysctl_value(key)
+  sysctld_value = get_sysctld_value(key)
+  if sysctl_value == sysctld_value
+    value(sysctl_value)
+  else
+    value('')
+  end
+
   if node.default['sysctl']['backup'][key].empty?
     node.default['sysctl']['backup'][key] = value
   end


### PR DESCRIPTION
### Description

Examine both the contents of `/etc/sysct.d` and the output of `sysctl -n` when determining what the current value of a param is.  If the two do not match, then the resource needs to be executed regardless.

### Issues Resolved

Fixes #112.

### Check List
- [ ] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
