### PR TITLE
Adding an explicit warning about major changes from v0.x to v1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Set [sysctl](http://en.wikipedia.org/wiki/Sysctl) system control parameters via Chef
 
+**Please read the changelog when upgrading from the v0.x series to the v1.x series**
+
 ## Requirements
 
 ### Platforms


### PR DESCRIPTION
### Description

Adding warning to users about v1.x breaking changes. README.md was too quiet to notify users about them.